### PR TITLE
No external dependencies for using the package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,1 @@
-black
-coverage
-flake8
-hypothesis
-mypy
-pylint
-pyperf
-pytest
-pytest-flake8
+


### PR DESCRIPTION
The split from single requirements spec into three may trigger changes to naive runners expecting to run tests with only requirements.txt dependencies resolved ...